### PR TITLE
Expires headers and ETag removal

### DIFF
--- a/h5bp-htaccess
+++ b/h5bp-htaccess
@@ -8,8 +8,6 @@
 ###   Block access to WordPress files that reveal version information.
 ###
 ### Removed:
-###   Expires headers:      Use W3 Total Cache
-###   ETag removal:         Use W3 Total Cache
 ###   Start rewrite engine: Handled by WordPress
 ###   Suppress/force www:   Handled by WordPress
 ###   Error handling:       Handled by WordPress


### PR DESCRIPTION
For users who don't want to use W3 Total Cache, it would be nice to have expires headers and etag removal kept in the .htaccess file. And even for users who do have a caching plugin, is there any downside to keeping these rules in the .htaccess?

Just my 2 cents :)
